### PR TITLE
fix issue where voting on question would lead to page refresh

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -68,25 +68,33 @@ class QuestionsController < ApplicationController
   def upvote
     @question = Question.find(params[:question_id])
     @question.upvote_from current_user
-    redirect_back fallback_location: root_path
+    respond_to do |format|
+      format.js
+    end
   end
 
   def downvote
     @question = Question.find(params[:question_id])
     @question.downvote_from current_user
-    redirect_back fallback_location: root_path
+    respond_to do |format|
+      format.js
+    end
   end
 
   def undoupvote
     @question = Question.find(params[:question_id])
     @question.unliked_by current_user
-    redirect_back fallback_location: root_path
+    respond_to do |format|
+      format.js
+    end
   end
 
   def undodownvote
     @question = Question.find(params[:question_id])
     @question.undisliked_by current_user
-    redirect_back fallback_location: root_path
+    respond_to do |format|
+      format.js
+    end
   end
 
   private

--- a/app/views/questions/_question.html.erb
+++ b/app/views/questions/_question.html.erb
@@ -1,0 +1,67 @@
+<!-- displays a question in the table of all questions -->
+
+
+<!-- right div: up/down arrows -->
+<div style="float:right">
+    <div> <!-- up arrow -->
+        <% if current_user.voted_up_on? question %>
+            <button class="btn btn-default btn-xs" disabled="true">
+             <span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span> 
+             </button>  
+        <% else %>
+            <% if current_user.voted_down_on? question %>
+                <%= button_to question_undodownvote_path(question), class:"btn btn-default btn-xs", method: :put, remote: true do %>
+                 <span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span>   
+                <% end %>           
+            <% else %>
+                <%= button_to question_upvote_path(question), class:"btn btn-default btn-xs", method: :put, remote: true do %>
+                 <span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span>   
+                <% end %>
+            <% end %>
+        <% end %>
+    </div>
+
+    <!-- current ranking -->
+    <div class="text-center" style="line-height: 20px;height: 20px;">
+        <%= question.weighted_score %>
+    </div>
+
+    <div> <!-- down arrow -->
+        <% if current_user.voted_down_on? question %>
+            <button class="btn btn-default btn-xs" disabled="true">
+                <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>
+            </button>   
+        <% else %>
+            <% if current_user.voted_up_on? question %>
+                <%= button_to question_undoupvote_path(question), class:"btn btn-default btn-xs", method: :put, remote: true do %>
+                    <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>   
+                <% end %>           
+            <% else %>
+                <%= button_to question_downvote_path(question), class:"btn btn-default btn-xs", method: :put, remote: true do %>
+                    <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>   
+                <% end %>
+            <% end %>
+        <% end %>
+    </div>
+</div>
+<!-- left div: question -->
+<div>
+    <!-- display question headline -->
+	<%= link_to question.headline, question, style:"font-size:16px" %>
+    <br>
+    <!-- display question content (first 75 chars) -->
+    <%= question.content.truncate(115) %>
+    <p>            
+      <% question.tag_list.each do |tag| %>
+            <a href="/tag/<%=tag%>" class="label label-pill label-info" style="text-decoration:none"><%= tag %></a>
+      <% end %>
+    </p>    
+    <!-- display how long ago the question was created-->
+    <div class="grey-text" style="font-size: 12px;">
+        <% if question.created_at > Time.now.beginning_of_day %>
+            <%="#{time_ago_in_words(question.created_at)} ago"%> 
+        <% else %>
+            <%= question.created_at.strftime("%b %d, %Y") %> 
+        <% end %>
+    </div>                                            
+</div>

--- a/app/views/questions/downvote.js.erb
+++ b/app/views/questions/downvote.js.erb
@@ -1,0 +1,1 @@
+$("#question_<%= @question.id %>").html("<%= escape_javascript(render partial: "questions/question", locals: {question: @question}) %>");

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -25,70 +25,8 @@
     	  <tbody>
     	    <% @questions.each do |question| %>
     	      <tr>
-    	        <td style="position:relative; padding:5px">
-                    <!-- right div: up/down arrows -->
-                    <div style="float:right">
-                        <div> <!-- up arrow -->
-                            <% if current_user.voted_up_on? question %>
-                                <button class="btn btn-default btn-xs" disabled="true">
-                                 <span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span> 
-                                 </button>  
-                            <% else %>
-                                <% if current_user.voted_down_on? question %>
-                                    <%= button_to question_undodownvote_path(question), class:"btn btn-default btn-xs", method: :put, remote: true do %>
-                                     <span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span>   
-                                    <% end %>           
-                                <% else %>
-                                    <%= button_to question_upvote_path(question), class:"btn btn-default btn-xs", method: :put, remote: true do %>
-                                     <span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span>   
-                                    <% end %>
-                                <% end %>
-                            <% end %>
-                        </div>
-
-                        <!-- current ranking -->
-                        <div class="text-center" style="line-height: 20px;height: 20px;">
-                            <%= question.weighted_score %>
-                        </div>
-                        <div> <!-- down arrow -->
-                            <% if current_user.voted_down_on? question %>
-                                <button class="btn btn-default btn-xs" disabled="true">
-                                    <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>
-                                </button>   
-                            <% else %>
-                                <% if current_user.voted_up_on? question %>
-                                    <%= button_to question_undoupvote_path(question), class:"btn btn-default btn-xs", method: :put, remote: true do %>
-                                        <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>   
-                                    <% end %>           
-                                <% else %>
-                                    <%= button_to question_downvote_path(question), class:"btn btn-default btn-xs", method: :put, remote: true do %>
-                                        <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>   
-                                    <% end %>
-                                <% end %>
-                            <% end %>
-                        </div>
-                    </div>
-                    <!-- left div: question -->
-                    <div>
-                        <!-- display question headline -->
-        	        	<%= link_to question.headline, question, style:"font-size:16px" %>
-                        <br>
-                        <!-- display question content (first 75 chars) -->
-                        <%= question.content.truncate(115) %>
-                        <p>            
-                          <% question.tag_list.each do |tag| %>
-                                <a href="/tag/<%=tag%>" class="label label-pill label-info" style="text-decoration:none"><%= tag %></a>
-                          <% end %>
-                        </p>    
-                        <!-- display how long ago the question was created-->
-                        <div class="grey-text" style="font-size: 12px;">
-                            <% if question.created_at > Time.now.beginning_of_day %>
-                                <%="#{time_ago_in_words(question.created_at)} ago"%> 
-                            <% else %>
-                                <%= question.created_at.strftime("%b %d, %Y") %> 
-                            <% end %>
-                        </div>                                            
-                    </div>
+    	        <td id="question_<%= question.id %>" style="position:relative; padding:5px">
+                    <%= render(partial: 'questions/question', locals: {question: question})%>
     			</td>
     	      </tr>
     	    <% end %>

--- a/app/views/questions/undodownvote.js.erb
+++ b/app/views/questions/undodownvote.js.erb
@@ -1,0 +1,1 @@
+$("#question_<%= @question.id %>").html("<%= escape_javascript(render partial: "questions/question", locals: {question: @question}) %>");

--- a/app/views/questions/undoupvote.js.erb
+++ b/app/views/questions/undoupvote.js.erb
@@ -1,0 +1,1 @@
+$("#question_<%= @question.id %>").html("<%= escape_javascript(render partial: "questions/question", locals: {question: @question}) %>");

--- a/app/views/questions/upvote.js.erb
+++ b/app/views/questions/upvote.js.erb
@@ -1,0 +1,1 @@
+$("#question_<%= @question.id %>").html("<%= escape_javascript(render partial: "questions/question", locals: {question: @question}) %>");


### PR DESCRIPTION
Using query on each of the four vote functions, added a unique id tag
to each question in the table.
Each question is now represented in a partial, ‘questions/question’
When vote functions called, reload the entire question partial but not
the page using jquery
This is done by a change in questions controller which responds with
format.js